### PR TITLE
del redundant `docs/requirements.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # insarmaps_scripts
+
 Collection of scripts to upload and manipulate data on https://insarmaps.miami.edu/
 
-# Installation
+## Installation
+
 The below install instructions have been tested on ubuntu 22.04. Installing on Windows/MacOS/other linux distributions will involve modifying the below commands to the equivalent ones on the target system.
 
 1. Install tippecanoe: https://github.com/mapbox/tippecanoe
 2. Install gdal: ```sudo apt-get install gdal-bin```
 3. Install Mintpy: https://github.com/insarlab/MintPy/blob/main/docs/installation.md
-4. Run pip install -r requirements.txt to install remaining requirements
+4. Run `pip install -r requirements.txt` to install remaining requirements
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-pycurl
-psycopg2
-defusedxml
-h5py
-numpy
-tippecanoe
-geocoder

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mintpy
 numpy
 psycopg2
 pycurl
+tippecanoe


### PR DESCRIPTION
+ add `tippecanoe` to `requirements.txt` so that it's the same as the `docs/requirements.txt`

+ remove the redundant `docs/requirements.txt`